### PR TITLE
fixed f64 column type def issues

### DIFF
--- a/src/workers/parse_csv.rs
+++ b/src/workers/parse_csv.rs
@@ -58,7 +58,7 @@ impl ParseFile {
             } else {
                 let mut col_index = 0;
                 for col_data in record.iter() {
-                    if data_types[col_index] != DataTypes::String {
+                    if data_types[col_index] != DataTypes::String && data_types[col_index] != DataTypes::F64 {
                         let potential_type = check_col_data_type(col_data);
                         if potential_type != data_types[col_index] {
                             data_types[col_index] = potential_type;
@@ -103,7 +103,7 @@ impl ParseFile {
             return "INVALID_COLUMN_NAME".to_string();
         }
 
-        println!("invalid struct field name: {}", name);
+        eprintln!("invalid struct field name: {}, fixing", name);
         if first_char.is_numeric() {
             return self.check_col_name(&format!("_{}", name));
         }

--- a/src/workers/sqlite.rs
+++ b/src/workers/sqlite.rs
@@ -50,13 +50,22 @@ impl SqliteDB {
                 let value = match col_value.parse::<i64>() {
                     Ok(v) => v,
                     Err(e) => {
-                        eprintln!("WARNING: i64 parse error: '{}' is not an int: {}", col_value, e);
+                        eprintln!("WARNING: i64 parse error: {} => '{}' is not an int: {}", col.name,  col_value, e);
                         0
                     }
                 };
                 Value::Integer(value)
             },
-            DataTypes::F64 => Value::Float(col_value.parse::<f64>().unwrap()),
+            DataTypes::F64 => {
+                let value = match col_value.parse::<f64>() {
+                    Ok(v) => v,
+                    Err(e) => {
+                        eprintln!("WARNING: f64 parse error: {} => '{}' f64 parse error: : {}", col.name, col_value, e);
+                        0.0
+                    }
+                };
+                Value::Float(value)
+            },
             DataTypes::Empty => Value::Null
         }
     }


### PR DESCRIPTION
Fixes issue #1 where f64 columns were being flagged as i64 columns.  Also added the column name to the warning messages in numeric type conversions.