### PR TITLE
[POC] Generate HTTP GET routes

### DIFF
--- a/src/workers/output.rs
+++ b/src/workers/output.rs
@@ -2,10 +2,8 @@
 // data is stored, typically it will be a database.  Maybe this should have
 // a vec of output types as a field so I can havae SQLite, Postgress, MySQL, 
 // etc...
-// use std::fs::File;
-// use std::io::Error;
-// use std::io::prelude::*;
-
+// TODO: Add projected directory which will be the base of the src and sql 
+// dir if neither path is given
 #[derive(Debug)]
 pub struct Output {
     pub src_directory: String,


### PR DESCRIPTION
Updates:

* generates the necessary code to handle HTTP Get requests for each of the generated entity and responds with a simple string message.  
* Generate a basic curl script to make sure that the routes respond
There is code to generate a basic curl script that makes calls to the newly generated routes. 
* Changed write_code_file to not apend .rs to the filename passed in. Now the caller must do that.  

Generated code compiles, runs and responds to my curl script as expected.